### PR TITLE
utf-8 issues

### DIFF
--- a/service.py
+++ b/service.py
@@ -132,9 +132,10 @@ def download(page_id, subtitle_id,filename, stack=False):
         xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (zip,__temp__,)).encode('utf-8'), True)
 
         for file in xbmcvfs.listdir(__temp__)[1]:
-            log(__name__, "file=%s" % file)
-            file = os.path.join(__temp__, file)
-            if (os.path.splitext(file)[1] in exts):
+            ufile=file.decode('utf-8')
+            log(__name__, "file=%s" % ufile)
+            file = os.path.join(__temp__, ufile)
+            if (os.path.splitext(ufile)[1] in exts):
               convert_to_utf(file)
               subtitle_list.append(file)
       


### PR DESCRIPTION
Bettr handling of utf-8/ascii issue in file name in kodi 15.2 / openelc / cubox
Before fix we can serach for subtitles and failed to complete the download and reencode to utf-8

I have tested this is my installation, but don't know how to publish and test a new version 1.06 for the addon