### PR TITLE
Fix Manual Search, Empty Title&Kodi isn't playing

### DIFF
--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -33,3 +33,23 @@ def convert_to_utf(file):
             output.write(srt_data)
     except UnicodeDecodeError:
         log(__name__, "got unicode decode error with reading subtitle data")
+
+def normalizeString(str):
+    return unicodedata.normalize(
+        'NFKD', unicode(unicode(str, 'utf-8'))
+    ).encode('utf-8', 'ignore')
+
+def check_and_parse_if_title_is_TVshow(manualTitle):
+    try:
+        tempShow,tempSE = manualTitle.split("%20")
+
+        indexS = tempSE.index("S")
+        indexE = tempSE.find("E")
+
+        tempS = tempSE[indexS+1:indexE]
+        tempE = tempSE[indexE+1:]
+
+        return [tempShow, tempS, tempE]
+
+    except:
+        return ["NotTVShow", "0", "0"]

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -7,6 +7,8 @@ import unicodedata
 import xbmcaddon
 import xbmc
 
+import re
+
 __addon__ = xbmcaddon.Addon()
 __version__ = __addon__.getAddonInfo('version')  # Module version
 __scriptname__ = __addon__.getAddonInfo('name')
@@ -34,22 +36,29 @@ def convert_to_utf(file):
     except UnicodeDecodeError:
         log(__name__, "got unicode decode error with reading subtitle data")
 
-def normalizeString(str):
-    return unicodedata.normalize(
-        'NFKD', unicode(unicode(str, 'utf-8'))
-    ).encode('utf-8', 'ignore')
-
 def check_and_parse_if_title_is_TVshow(manualTitle):
     try:
-        tempShow,tempSE = manualTitle.split("%20")
+        manualTitle = manualTitle.replace("%20", " ")
 
-        indexS = tempSE.index("S")
-        indexE = tempSE.find("E")
+        matchShow = re.search(r'(?i)^(.*?)\sS\d\d', manualTitle)
+        if matchShow == None:
+            return ["NotTVShow", "0", "0"]
+        else:
+            tempShow = matchShow.group(1)
+        
+        matchSnum = re.search(r'(?i)%s(.*?)E' %(tempShow+" s"), manualTitle)
+        if matchSnum == None:
+            return ["NotTVShow", "0", "0"]
+        else:
+            tempSnum = matchSnum.group(1)
+        
+        matchEnum = re.search(r'(?i)%s(.*?)$' %(tempShow+" s"+tempSnum+"e"), manualTitle)
+        if matchEnum == None:
+            return ["NotTVShow", "0", "0"]
+        else:
+            tempEnum = matchEnum.group(1)
 
-        tempS = tempSE[indexS+1:indexE]
-        tempE = tempSE[indexE+1:]
-
-        return [tempShow, tempS, tempE]
+        return [tempShow, tempSnum, tempEnum]
 
     except:
         return ["NotTVShow", "0", "0"]

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -40,7 +40,7 @@ def check_and_parse_if_title_is_TVshow(manualTitle):
     try:
         manualTitle = manualTitle.replace("%20", " ")
 
-        matchShow = re.search(r'(?i)^(.*?)\sS\d\d', manualTitle)
+        matchShow = re.search(r'(?i)^(.*?)\sS\d', manualTitle)
         if matchShow == None:
             return ["NotTVShow", "0", "0"]
         else:

--- a/service.py
+++ b/service.py
@@ -14,7 +14,6 @@ import xbmcgui
 import xbmcplugin
 import xbmcvfs
 
-
 __addon__ = xbmcaddon.Addon()
 __author__ = __addon__.getAddonInfo('author')
 __scriptid__ = __addon__.getAddonInfo('id')
@@ -39,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf
+from SubtitleHelper import log, normalize_string, convert_to_utf, normalizeString, check_and_parse_if_title_is_TVshow
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -51,11 +50,20 @@ def search(item):
 
     try:
         search_start_time = time.time()
-        if item['tvshow'] != "":
-            subtitles_options = downloader.search_tvshow(item['tvshow'], item['season'], item['episode'])
+        
+        if (item['mansearch'] == False):
+            if item['tvshow'] != "":
+                subtitles_options = downloader.search_tvshow(item['tvshow'], item['season'], item['episode'])
+            else:              
+                title, year = xbmc.getCleanMovieTitle(item['title'])
+                subtitles_options = downloader.search_movie(title)
         else:
-            title, year = xbmc.getCleanMovieTitle(item['title'])
-            subtitles_options = downloader.search_movie(title)
+            item['tvshow'], item['season'], item['episode'] = check_and_parse_if_title_is_TVshow(item['title'])
+            subtitles_options = downloader.search_tvshow(item['tvshow'], int(item['season']), int(item['episode']))
+            if (subtitles_options == None): # This is a movie title
+                item['title'] = item['title'].replace("%20", "%2b") # " " to "+"
+                title, year = xbmc.getCleanMovieTitle(item['title'])
+                subtitles_options = downloader.search_movie(title)
                     
         log(__name__, "search took %f" % (time.time() - search_start_time))
     except Exception as e:
@@ -173,37 +181,43 @@ params = get_params()
 if params['action'] == 'search' or params['action'] == 'manualsearch':
     log(__name__, "action '%s' called" % params['action'])
     item = dict()
-    item['temp'] = False
-    item['rar'] = False
-    item['mansearch'] = False
-    item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
-    item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
-    item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
-    item['tvshow'] = normalize_string(xbmc.getInfoLabel(
-        "VideoPlayer.TVshowtitle")
-    )  # Show
-    item['title'] = normalize_string(xbmc.getInfoLabel(
-        "VideoPlayer.OriginalTitle")
-    )  # try to get original title
-    item['file_original_path'] = urllib.unquote(
-        xbmc.Player().getPlayingFile().decode('utf-8')
-    )  # Full path of a playing file
-    item['3let_language'] = []
 
-    if 'searchstring' in params:
-        item['mansearch'] = True
-        item['mansearchstr'] = params['searchstring']
-
-    for lang in urllib.unquote(params['languages']).decode('utf-8').split(","):
-        item['3let_language'].append(
-            xbmc.convertLanguage(lang, xbmc.ISO_639_2)
-        )
+    if xbmc.Player().isPlaying():
+        item['temp'] = False
+        item['rar'] = False
+        item['mansearch'] = False
+        item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
+        item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
+        item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
+        item['tvshow'] = normalize_string(xbmc.getInfoLabel(
+            "VideoPlayer.TVshowtitle")
+        )  # Show
+        item['title'] = normalize_string(xbmc.getInfoLabel(
+            "VideoPlayer.OriginalTitle")
+        )  # try to get original title
+        item['file_original_path'] = urllib.unquote(
+            xbmc.Player().getPlayingFile().decode('utf-8')
+        )  # Full path of a playing file
+        item['3let_language'] = []
+    else:
+        item['temp'] = False
+        item['rar'] = False
+        item['mansearch'] = False
+        item['year'] = ""
+        item['season'] = ""
+        item['episode'] = ""
+        item['tvshow'] = ""
+        item['title'] = "SearchFor..."
+        item['file_original_path'] = ""
+        item['3let_language'] = []
 
     if item['title'] == "":
         log(__name__, "VideoPlayer.OriginalTitle not found")
-        item['title'] = normalize_string(
-            xbmc.getInfoLabel("VideoPlayer.Title")
-        ) # no original title, get just Title
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+
+    if 'searchstring' in params:
+        item['mansearch'] = True
+        item['title'] = params['searchstring']
 
     if item['episode'].lower().find("s") > -1:  # Check if season is "Special"
         item['season'] = "0"

--- a/service.py
+++ b/service.py
@@ -207,7 +207,7 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = "SearchFor..."
+        item['title'] = "SearchFor..." #Needed to avoid showing previous search result.
         item['file_original_path'] = ""
         item['3let_language'] = []
 

--- a/service.py
+++ b/service.py
@@ -38,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf, normalizeString, check_and_parse_if_title_is_TVshow
+from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -59,12 +59,13 @@ def search(item):
                 subtitles_options = downloader.search_movie(title)
         else:
             item['tvshow'], item['season'], item['episode'] = check_and_parse_if_title_is_TVshow(item['title'])
-            subtitles_options = downloader.search_tvshow(item['tvshow'], int(item['season']), int(item['episode']))
-            if (subtitles_options == None): # This is a movie title
+            if (item['tvshow'] == "NotTVShow"):
                 item['title'] = item['title'].replace("%20", "%2b") # " " to "+"
                 title, year = xbmc.getCleanMovieTitle(item['title'])
                 subtitles_options = downloader.search_movie(title)
-                    
+            else:
+                subtitles_options = downloader.search_tvshow(item['tvshow'], int(item['season']), int(item['episode']))
+                                    
         log(__name__, "search took %f" % (time.time() - search_start_time))
     except Exception as e:
         log(
@@ -207,13 +208,13 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = "SearchFor..." #Needed to avoid showing previous search result.
+        item['title'] = "SearchFor..." # Needed to avoid showing previous search result.
         item['file_original_path'] = ""
         item['3let_language'] = []
 
     if item['title'] == "":
         log(__name__, "VideoPlayer.OriginalTitle not found")
-        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+        item['title'] = normalize_string(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
 
     if 'searchstring' in params:
         item['mansearch'] = True


### PR DESCRIPTION
* Fix the Manual Search which have not worked until now. 

* Add support when title is given as an empty string (This happens with some addons)

* Add the option for using the addon when kodi isn't playing:
** Open the Subtitles Dialog outside the player can be done by add it in the Keymap xml files.
** This fix doesn't change the normal operation as it today when kodi is playing media.
** This fix have been tested by me (burekas)
** The mainly changes are by add a condition when kodi playing or not
playing: if xbmc.Player().isPlaying()
** There is no exception when subtitle is downloaded