### PR TITLE
Improvement for PR #40 - Title will be taken from the focused item + 2 fixes

### DIFF
--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -8,10 +8,13 @@ import xbmcaddon
 import xbmc
 
 import re
+import os
 
 __addon__ = xbmcaddon.Addon()
 __version__ = __addon__.getAddonInfo('version')  # Module version
 __scriptname__ = __addon__.getAddonInfo('name')
+
+regexHelper = re.compile('\W+', re.UNICODE)
 
 def log(module, msg):
     xbmc.log((u"### [%s] - %s" % (module, msg,)).encode('utf-8'), level=xbmc.LOGDEBUG)
@@ -78,3 +81,56 @@ def take_title_from_focused_item():
         title = ("%s S%.2dE%.2d" % (labelTVShowTitle, int(labelSeason), int(labelEpisode))).replace(" ", "%20")
 
     return title
+
+def parse_rls_title(item):
+    title = regexHelper.sub(' ', item["title"])
+    tvshow = regexHelper.sub(' ', item["tvshow"])
+
+    groups = re.findall(r"(.*?) (\d{4})? ?(?:s|season|)(\d{1,2})(?:e|episode|x|\n)(\d{1,2})", title, re.I)
+
+    if len(groups) == 0:
+        groups = re.findall(r"(.*?) (\d{4})? ?(?:s|season|)(\d{1,2})(?:e|episode|x|\n)(\d{1,2})", tvshow, re.I)
+
+    if len(groups) > 0 and len(groups[0]) >= 3:
+        title, year, season, episode = groups[0]
+        item["year"] = str(int(year)) if len(year) == 4 else year
+
+        item["tvshow"] = regexHelper.sub(' ', title).strip()
+        item["season"] = str(int(season))
+        item["episode"] = str(int(episode))
+        log(__name__, "TV Parsed Item: %s" % (item,))
+
+    else:
+        groups = re.findall(r"(.*?)(\d{4})", item["title"], re.I)
+        if len(groups) > 0 and len(groups[0]) >= 1:
+            title = groups[0][0]
+            item["title"] = regexHelper.sub(' ', title).strip()
+            item["year"] = groups[0][1] if len(groups[0]) == 2 else item["year"]
+
+            log(__name__, "MOVIE Parsed Item: %s" % (item,))
+
+def clean_title(item):
+    title = os.path.splitext(os.path.basename(item["title"]))
+    tvshow = os.path.splitext(os.path.basename(item["tvshow"]))
+
+    if len(title) > 1:
+        if re.match(r'^\.[a-z]{2,4}$', title[1], re.IGNORECASE):
+            item["title"] = title[0]
+        else:
+            item["title"] = ''.join(title)
+    else:
+        item["title"] = title[0]
+
+    if len(tvshow) > 1:
+        if re.match(r'^\.[a-z]{2,4}$', tvshow[1], re.IGNORECASE):
+            item["tvshow"] = tvshow[0]
+        else:
+            item["tvshow"] = ''.join(tvshow)
+    else:
+        item["tvshow"] = tvshow[0]
+
+    item["title"] = unicode(item["title"], "utf-8")
+    item["tvshow"] = unicode(item["tvshow"], "utf-8")
+    # Removes country identifier at the end
+    item["title"] = re.sub(r'\([^\)]+\)\W*$', '', item["title"]).strip()
+    item["tvshow"] = re.sub(r'\([^\)]+\)\W*$', '', item["tvshow"]).strip()

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -33,3 +33,23 @@ def convert_to_utf(file):
             output.write(srt_data)
     except UnicodeDecodeError:
         log(__name__, "got unicode decode error with reading subtitle data")
+
+def normalizeString(str):
+    return unicodedata.normalize(
+        'NFKD', unicode(unicode(str, 'utf-8'))
+    ).encode('utf-8', 'ignore')
+
+def check_and_parse_if_title_is_TVshow(manualTitle):
+    try:
+        tempShow,tempSE = manualTitle.split("%20")
+
+        indexS = tempSE.index("S")
+        indexE = tempSE.find("E")
+
+        tempS = tempSE[indexS+1:indexE]
+        tempE = tempSE[indexE+1:]
+
+        return [tempShow, tempS, tempE]
+
+    except:
+        return ["NotTVShow", "0", "0"]

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -7,6 +7,8 @@ import unicodedata
 import xbmcaddon
 import xbmc
 
+import re
+
 __addon__ = xbmcaddon.Addon()
 __version__ = __addon__.getAddonInfo('version')  # Module version
 __scriptname__ = __addon__.getAddonInfo('name')
@@ -34,22 +36,29 @@ def convert_to_utf(file):
     except UnicodeDecodeError:
         log(__name__, "got unicode decode error with reading subtitle data")
 
-def normalizeString(str):
-    return unicodedata.normalize(
-        'NFKD', unicode(unicode(str, 'utf-8'))
-    ).encode('utf-8', 'ignore')
-
 def check_and_parse_if_title_is_TVshow(manualTitle):
     try:
-        tempShow,tempSE = manualTitle.split("%20")
+        manualTitle = manualTitle.replace("%20", " ")
 
-        indexS = tempSE.index("S")
-        indexE = tempSE.find("E")
+        matchShow = re.search(r'(?i)^(.*?)\sS\d\d', manualTitle)
+        if matchShow == None:
+            return ["NotTVShow", "0", "0"]
+        else:
+            tempShow = matchShow.group(1)
+        
+        matchSnum = re.search(r'(?i)%s(.*?)E' %(tempShow+" s"), manualTitle)
+        if matchSnum == None:
+            return ["NotTVShow", "0", "0"]
+        else:
+            tempSnum = matchSnum.group(1)
+        
+        matchEnum = re.search(r'(?i)%s(.*?)$' %(tempShow+" s"+tempSnum+"e"), manualTitle)
+        if matchEnum == None:
+            return ["NotTVShow", "0", "0"]
+        else:
+            tempEnum = matchEnum.group(1)
 
-        tempS = tempSE[indexS+1:indexE]
-        tempE = tempSE[indexE+1:]
-
-        return [tempShow, tempS, tempE]
+        return [tempShow, tempSnum, tempEnum]
 
     except:
         return ["NotTVShow", "0", "0"]

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -62,3 +62,32 @@ def check_and_parse_if_title_is_TVshow(manualTitle):
 
     except:
         return ["NotTVShow", "0", "0"]
+
+def take_title_from_focused_item():
+    try:
+        labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode
+        labelMovieTitle = xbmc.getInfoLabel("ListItem.OriginalTitle")
+        labelYear = xbmc.getInfoLabel("ListItem.Year")
+        labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
+        labelSeason = xbmc.getInfoLabel("ListItem.Season")
+        labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
+
+        if labelType == 'movie':
+            if labelMovieTitle and labelYear:
+                labelMovie = labelMovieTitle + "%20" + labelYear
+                return labelMovie
+            else:
+                return "SearchFor..."
+
+        elif labelType == 'episode':
+            if labelTVShowTitle and labelSeason and labelEpisode:
+                labelShow = ("%s S%.2dE%.2d" % (labelTVShowTitle, int(labelSeason), int(labelEpisode))).replace(" ", "%20")
+                return labelShow
+            else:
+                return "SearchFor..."
+    
+        else:
+            return "SearchFor..."  # Needed to avoid showing previous search result => In order to present "No Subtitles Found" result.
+    
+    except:
+            return "SearchFor..."

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -40,7 +40,7 @@ def check_and_parse_if_title_is_TVshow(manualTitle):
     try:
         manualTitle = manualTitle.replace("%20", " ")
 
-        matchShow = re.search(r'(?i)^(.*?)\sS\d\d', manualTitle)
+        matchShow = re.search(r'(?i)^(.*?)\sS\d', manualTitle)
         if matchShow == None:
             return ["NotTVShow", "0", "0"]
         else:

--- a/resources/lib/SubtitleHelper.py
+++ b/resources/lib/SubtitleHelper.py
@@ -64,30 +64,17 @@ def check_and_parse_if_title_is_TVshow(manualTitle):
         return ["NotTVShow", "0", "0"]
 
 def take_title_from_focused_item():
-    try:
-        labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode
-        labelMovieTitle = xbmc.getInfoLabel("ListItem.OriginalTitle")
-        labelYear = xbmc.getInfoLabel("ListItem.Year")
-        labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
-        labelSeason = xbmc.getInfoLabel("ListItem.Season")
-        labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
+    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode
+    labelMovieTitle = xbmc.getInfoLabel("ListItem.OriginalTitle")
+    labelYear = xbmc.getInfoLabel("ListItem.Year")
+    labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
+    labelSeason = xbmc.getInfoLabel("ListItem.Season")
+    labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
 
-        if labelType == 'movie':
-            if labelMovieTitle and labelYear:
-                labelMovie = labelMovieTitle + "%20" + labelYear
-                return labelMovie
-            else:
-                return "SearchFor..."
+    title = 'SearchFor ...'
+    if labelType == 'movie' and labelMovieTitle and labelYear:
+        title = labelMovieTitle + " " + labelYear
+    elif labelType == 'episode' and labelTVShowTitle and labelSeason and labelEpisode:
+        title = ("%s S%.2dE%.2d" % (labelTVShowTitle, int(labelSeason), int(labelEpisode))).replace(" ", "%20")
 
-        elif labelType == 'episode':
-            if labelTVShowTitle and labelSeason and labelEpisode:
-                labelShow = ("%s S%.2dE%.2d" % (labelTVShowTitle, int(labelSeason), int(labelEpisode))).replace(" ", "%20")
-                return labelShow
-            else:
-                return "SearchFor..."
-    
-        else:
-            return "SearchFor..."  # Needed to avoid showing previous search result => In order to present "No Subtitles Found" result.
-    
-    except:
-            return "SearchFor..."
+    return title

--- a/resources/lib/TorecSubtitlesDownloader.py
+++ b/resources/lib/TorecSubtitlesDownloader.py
@@ -41,7 +41,7 @@ class TVShowPage():
             return None
 
         episode_options = season_div[0].findAll("a")
-        episode_option = next((episode_option for episode_option in episode_options if (episode_option.contents[0] == u'פרק %s' % episode_number)), None)
+        episode_option = next((episode_option for episode_option in episode_options if ((episode_option.contents[0] == u'פרק %s' % episode_number) or (episode_option.contents[0] == u'פרק %s - אחרון לעונה' % episode_number))), None)
         if not episode_option:
             return None
 

--- a/service.py
+++ b/service.py
@@ -14,7 +14,6 @@ import xbmcgui
 import xbmcplugin
 import xbmcvfs
 
-
 __addon__ = xbmcaddon.Addon()
 __author__ = __addon__.getAddonInfo('author')
 __scriptid__ = __addon__.getAddonInfo('id')
@@ -39,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf
+from SubtitleHelper import log, normalize_string, convert_to_utf, normalizeString, check_and_parse_if_title_is_TVshow
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -51,11 +50,20 @@ def search(item):
 
     try:
         search_start_time = time.time()
-        if item['tvshow'] != "":
-            subtitles_options = downloader.search_tvshow(item['tvshow'], item['season'], item['episode'])
+        
+        if (item['mansearch'] == False):
+            if item['tvshow'] != "":
+                subtitles_options = downloader.search_tvshow(item['tvshow'], item['season'], item['episode'])
+            else:              
+                title, year = xbmc.getCleanMovieTitle(item['title'])
+                subtitles_options = downloader.search_movie(title)
         else:
-            title, year = xbmc.getCleanMovieTitle(item['title'])
-            subtitles_options = downloader.search_movie(title)
+            item['tvshow'], item['season'], item['episode'] = check_and_parse_if_title_is_TVshow(item['title'])
+            subtitles_options = downloader.search_tvshow(item['tvshow'], int(item['season']), int(item['episode']))
+            if (subtitles_options == None): # This is a movie title
+                item['title'] = item['title'].replace("%20", "%2b") # " " to "+"
+                title, year = xbmc.getCleanMovieTitle(item['title'])
+                subtitles_options = downloader.search_movie(title)
                     
         log(__name__, "search took %f" % (time.time() - search_start_time))
     except Exception as e:
@@ -173,37 +181,43 @@ params = get_params()
 if params['action'] == 'search' or params['action'] == 'manualsearch':
     log(__name__, "action '%s' called" % params['action'])
     item = dict()
-    item['temp'] = False
-    item['rar'] = False
-    item['mansearch'] = False
-    item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
-    item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
-    item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
-    item['tvshow'] = normalize_string(xbmc.getInfoLabel(
-        "VideoPlayer.TVshowtitle")
-    )  # Show
-    item['title'] = normalize_string(xbmc.getInfoLabel(
-        "VideoPlayer.OriginalTitle")
-    )  # try to get original title
-    item['file_original_path'] = urllib.unquote(
-        xbmc.Player().getPlayingFile().decode('utf-8')
-    )  # Full path of a playing file
-    item['3let_language'] = []
 
-    if 'searchstring' in params:
-        item['mansearch'] = True
-        item['mansearchstr'] = params['searchstring']
-
-    for lang in urllib.unquote(params['languages']).decode('utf-8').split(","):
-        item['3let_language'].append(
-            xbmc.convertLanguage(lang, xbmc.ISO_639_2)
-        )
+    if xbmc.Player().isPlaying():
+        item['temp'] = False
+        item['rar'] = False
+        item['mansearch'] = False
+        item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
+        item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
+        item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
+        item['tvshow'] = normalize_string(xbmc.getInfoLabel(
+            "VideoPlayer.TVshowtitle")
+        )  # Show
+        item['title'] = normalize_string(xbmc.getInfoLabel(
+            "VideoPlayer.OriginalTitle")
+        )  # try to get original title
+        item['file_original_path'] = urllib.unquote(
+            xbmc.Player().getPlayingFile().decode('utf-8')
+        )  # Full path of a playing file
+        item['3let_language'] = []
+    else:
+        item['temp'] = False
+        item['rar'] = False
+        item['mansearch'] = False
+        item['year'] = ""
+        item['season'] = ""
+        item['episode'] = ""
+        item['tvshow'] = ""
+        item['title'] = "SearchFor..."
+        item['file_original_path'] = ""
+        item['3let_language'] = []
 
     if item['title'] == "":
         log(__name__, "VideoPlayer.OriginalTitle not found")
-        item['title'] = normalize_string(
-            xbmc.getInfoLabel("VideoPlayer.Title")
-        ) # no original title, get just Title
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+
+    if 'searchstring' in params:
+        item['mansearch'] = True
+        item['title'] = params['searchstring']
 
     if item['episode'].lower().find("s") > -1:  # Check if season is "Special"
         item['season'] = "0"

--- a/service.py
+++ b/service.py
@@ -203,7 +203,6 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     else:
         item['temp'] = False
         item['rar'] = False
-        item['mansearch'] = False
         item['year'] = ""
         item['season'] = ""
         item['episode'] = ""

--- a/service.py
+++ b/service.py
@@ -225,9 +225,10 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
 
     log(__name__, "Item before cleaning: \n    %s" % item)
 
-    # clean title + tvshow params
-    clean_title(item)
-    parse_rls_title(item)
+    if xbmc.Player().isPlaying():
+        # clean title + tvshow params
+        clean_title(item)
+        parse_rls_title(item)
 
     if item['episode'].lower().find("s") > -1:  # Check if season is "Special"
         item['season'] = "0"

--- a/service.py
+++ b/service.py
@@ -38,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow
+from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow, take_title_from_focused_item
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -208,7 +208,8 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = "SearchFor..." # Needed to avoid showing previous search result.
+        item['title'] = take_title_from_focused_item()
+        item['mansearch'] = True
         item['file_original_path'] = ""
         item['3let_language'] = []
 

--- a/service.py
+++ b/service.py
@@ -207,7 +207,7 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = "SearchFor..."
+        item['title'] = "SearchFor..." #Needed to avoid showing previous search result.
         item['file_original_path'] = ""
         item['3let_language'] = []
 

--- a/service.py
+++ b/service.py
@@ -38,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow, take_title_from_focused_item
+from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow, take_title_from_focused_item, parse_rls_title, clean_title
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -219,6 +219,15 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     if 'searchstring' in params:
         item['mansearch'] = True
         item['title'] = params['searchstring']
+
+    for lang in unicode(urllib.unquote(params['languages']), 'utf-8').split(","):
+        item['3let_language'].append(xbmc.convertLanguage(lang, xbmc.ISO_639_2))
+
+    log(__name__, "Item before cleaning: \n    %s" % item)
+
+    # clean title + tvshow params
+    clean_title(item)
+    parse_rls_title(item)
 
     if item['episode'].lower().find("s") > -1:  # Check if season is "Special"
         item['season'] = "0"

--- a/service.py
+++ b/service.py
@@ -38,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf, normalizeString, check_and_parse_if_title_is_TVshow
+from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -59,12 +59,13 @@ def search(item):
                 subtitles_options = downloader.search_movie(title)
         else:
             item['tvshow'], item['season'], item['episode'] = check_and_parse_if_title_is_TVshow(item['title'])
-            subtitles_options = downloader.search_tvshow(item['tvshow'], int(item['season']), int(item['episode']))
-            if (subtitles_options == None): # This is a movie title
+            if (item['tvshow'] == "NotTVShow"):
                 item['title'] = item['title'].replace("%20", "%2b") # " " to "+"
                 title, year = xbmc.getCleanMovieTitle(item['title'])
                 subtitles_options = downloader.search_movie(title)
-                    
+            else:
+                subtitles_options = downloader.search_tvshow(item['tvshow'], int(item['season']), int(item['episode']))
+                                    
         log(__name__, "search took %f" % (time.time() - search_start_time))
     except Exception as e:
         log(
@@ -207,13 +208,13 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = "SearchFor..." #Needed to avoid showing previous search result.
+        item['title'] = "SearchFor..." # Needed to avoid showing previous search result.
         item['file_original_path'] = ""
         item['3let_language'] = []
 
     if item['title'] == "":
         log(__name__, "VideoPlayer.OriginalTitle not found")
-        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
+        item['title'] = normalize_string(xbmc.getInfoLabel("VideoPlayer.Title"))  # no original title, get just Title
 
     if 'searchstring' in params:
         item['mansearch'] = True

--- a/service.py
+++ b/service.py
@@ -223,9 +223,8 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     for lang in unicode(urllib.unquote(params['languages']), 'utf-8').split(","):
         item['3let_language'].append(xbmc.convertLanguage(lang, xbmc.ISO_639_2))
 
-    log(__name__, "Item before cleaning: \n    %s" % item)
-
     if xbmc.Player().isPlaying():
+        log(__name__, "Item before cleaning: \n    %s" % item)
         # clean title + tvshow params
         clean_title(item)
         parse_rls_title(item)


### PR DESCRIPTION
> Improvement for the option of using the addon when kodi is not playing:
* Now the title will be taken from the focused item when it has details (For example: Kodi Library, Exodus. But with Salts, Quasar, Specto this will still not work until their developers will fix it)
* If it doesn't have details, it will remain "SearchFor" in order to present "No Subtitles Found" result, so you can typing it manually in the "Manual Search"

> Add support for local tvshow content

> Fix bug for last episode in a season that didn't return results.