### PR TITLE
Fix torec new download method

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.torec"
        name="Torec"
-       version="1.3.2"
+       version="1.3.3"
        provider-name="slmosl">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.torec"
        name="Torec"
-       version="1.3.0"
+       version="1.3.1"
        provider-name="slmosl">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
@@ -11,7 +11,7 @@
   <extension point="xbmc.subtitle.module"
              library="service.py" />
   <extension point="xbmc.addon.metadata">
-    <summary lang="en">Kodi/XBMC Torec Subtitles allows for downloading hebrew subtitles from the Israeli site Torec.net</summary>
+    <summary lang="en">Kodi/XBMC Torec Subtitles allows for downloading hebrew subtitles from the Israeli site Torec.net - Works for registered users only!</summary>
     <description lang="en">Search and download various hebrew subtitles from the Israeli subtitles site Torec.net.</description>
     <source>https://github.com/slmosl/service.subtitles.Torec</source>
     <email></email>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.torec"
        name="Torec"
-       version="1.3.1"
+       version="1.3.2"
        provider-name="slmosl">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/resources/lib/TorecSubtitlesDownloader.py
+++ b/resources/lib/TorecSubtitlesDownloader.py
@@ -95,11 +95,11 @@ class FirefoxURLHandler(object):
 
             )
         ]
+        self.__addon__ = xbmcaddon.Addon(id="service.subtitles.torec")
 
     def login(self):
-        __addon__ = xbmcaddon.Addon(id="service.subtitles.torec")
-        username = __addon__.getSetting("username")
-        password = __addon__.getSetting("password")
+        username = self.__addon__.getSetting("username")
+        password = self.__addon__.getSetting("password")
         login_data_ = {
             "ref": "http://www.torec.net/",
             "form": "true",
@@ -150,8 +150,8 @@ class TorecSubtitlesDownloader(FirefoxURLHandler):
 
     def __init__(self):
         super(TorecSubtitlesDownloader, self).__init__()
-        if login() is False:
-            __addon__.openSettings()
+        if self.login() is False:
+            self.__addon__.openSettings()
 
     def _build_default_cookie(self, sub_id):
         current_time = datetime.datetime.now().strftime("%m/%d/%Y+%I:%M:%S+%p")

--- a/resources/lib/TorecSubtitlesDownloader.py
+++ b/resources/lib/TorecSubtitlesDownloader.py
@@ -12,6 +12,7 @@ import itertools
 import bs4
 
 import xbmc
+import xbmcaddon
 from SubtitleHelper import log
 
 class SubtitleOption(object):
@@ -96,18 +97,18 @@ class FirefoxURLHandler(object):
         ]
 
     def login(self):
+        __addon__ = xbmcaddon.Addon(id="service.subtitles.torec")
         username = __addon__.getSetting("username")
         password = __addon__.getSetting("password")
         login_data_ = {
-            "ref": "/Default.asp?",
-            "Form": "True",
-            "site": "true",
+            "ref": "http://www.torec.net/",
+            "form": "true",
             "username": username,
             "password": password,
-            "login": "submit"
         }
         login_data = urllib.urlencode(login_data_)
-        login_url = "http://www.torec.net/login.asp"
+        # Replace number with random
+        login_url = 'http://www.torec.net/ajax/login/t7/loginProcess.asp?rnd={0}'.format('0.46673249283')
         response = self.opener.open(login_url, login_data)
         content = ''.join(response.readlines())
         return username in content
@@ -135,7 +136,9 @@ class TorecGuestTokenGenerator():
         return self._encode_ticket(self._gen_plain_ticket(sub_id, secs_ago))
 
 class TorecSubtitlesDownloader(FirefoxURLHandler):
-    MAXIMUM_WAIT_TIME_MSEC = 13 * 1000
+    # Disable the 13 sec waiting due to capcha as guest.
+    # Need to verify login before downloading
+    MAXIMUM_WAIT_TIME_MSEC = 1 * 1000
 
     DEFAULT_SEPERATOR = " "
     BASE_URL          = "http://www.xn--9dbf0cd.net"
@@ -147,6 +150,8 @@ class TorecSubtitlesDownloader(FirefoxURLHandler):
 
     def __init__(self):
         super(TorecSubtitlesDownloader, self).__init__()
+        if login() is False:
+            __addon__.openSettings()
 
     def _build_default_cookie(self, sub_id):
         current_time = datetime.datetime.now().strftime("%m/%d/%Y+%I:%M:%S+%p")
@@ -263,8 +268,8 @@ class TorecSubtitlesDownloader(FirefoxURLHandler):
                 "sub_id":     sub_id,
                 "code":       option_id,
                 "sh":         "yes",
-                "guest":      guest_token,
-                "timewaited": 13
+                "guest":      "",
+                "timewaited": "-1"
         })
 
         download_link  = None

--- a/tests/movie_tests.py
+++ b/tests/movie_tests.py
@@ -41,7 +41,6 @@ class MovieTests(unittest.TestCase):
 
 		result                 = self.downloader.get_download_link(page_id, subtitle_id)
 		subtitleData, fileName = self.downloader.download(result)
-		pdb.set_trace()
 		self.assertIsNotNone(subtitleData)
 
 		self._assert_subtitle_data(subtitleData, fileName)

--- a/tests/movie_tests.py
+++ b/tests/movie_tests.py
@@ -18,18 +18,18 @@ class MovieTests(unittest.TestCase):
 	def setUpClass(self):
 		self.downloader  = TorecSubtitlesDownloader()
 
-	#def test_search_movie_sanity(self):
-	#	item    = self._create_test_valid_item()
-	#	options = self.downloader.search_movie(item['title'])
-	#	self.assertIsNotNone(options)
-	#	self.assertEqual(len(options), 22)
+	def test_search_movie_sanity(self):
+		item    = self._create_test_valid_item()
+		options = self.downloader.search_movie(item['title'])
+		self.assertIsNotNone(options)
+		self.assertEqual(len(options), 22)
 
-	#def test_search_inexisting_movie(self):
-	#	item = {
-	#		'title': 'finding mori',
-	#	}
-	#	options = self.downloader.search_movie(item['title'])
-	#	self.assertIsNone(options)
+	def test_search_inexisting_movie(self):
+		item = {
+			'title': 'finding mori',
+		}
+		options = self.downloader.search_movie(item['title'])
+		self.assertIsNone(options)
 
 	def test_download_movie_sanity(self):
 		item    = self._create_test_valid_item()
@@ -39,7 +39,6 @@ class MovieTests(unittest.TestCase):
 		page_id     = option.sub_id
 		subtitle_id = option.option_id
 
-		self.downloader.login()
 		result                 = self.downloader.get_download_link(page_id, subtitle_id)
 		subtitleData, fileName = self.downloader.download(result)
 		pdb.set_trace()

--- a/tests/movie_tests.py
+++ b/tests/movie_tests.py
@@ -1,4 +1,5 @@
 import os
+import pdb
 import sys
 import time
 import rarfile
@@ -9,6 +10,7 @@ import unittest
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../resources/lib")
 
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
+from TorecSubtitlesDownloader import FirefoxURLHandler
 from SubtitleHelper import convert_to_utf
 
 class MovieTests(unittest.TestCase):
@@ -16,19 +18,18 @@ class MovieTests(unittest.TestCase):
 	def setUpClass(self):
 		self.downloader  = TorecSubtitlesDownloader()
 
-	def test_search_movie_sanity(self):
-		item    = self._create_test_valid_item()
-		options = self.downloader.search_movie(item['title'])
-		self.assertIsNotNone(options)
-		self.assertEqual(len(options), 22)
+	#def test_search_movie_sanity(self):
+	#	item    = self._create_test_valid_item()
+	#	options = self.downloader.search_movie(item['title'])
+	#	self.assertIsNotNone(options)
+	#	self.assertEqual(len(options), 22)
 
-	def test_search_inexisting_movie(self):
-		item = {
-			'title': 'finding mori',
-		}
-
-		options = self.downloader.search_movie(item['title'])
-		self.assertIsNone(options)
+	#def test_search_inexisting_movie(self):
+	#	item = {
+	#		'title': 'finding mori',
+	#	}
+	#	options = self.downloader.search_movie(item['title'])
+	#	self.assertIsNone(options)
 
 	def test_download_movie_sanity(self):
 		item    = self._create_test_valid_item()
@@ -38,16 +39,16 @@ class MovieTests(unittest.TestCase):
 		page_id     = option.sub_id
 		subtitle_id = option.option_id
 
+		self.downloader.login()
 		result                 = self.downloader.get_download_link(page_id, subtitle_id)
 		subtitleData, fileName = self.downloader.download(result)
+		pdb.set_trace()
 		self.assertIsNotNone(subtitleData)
 
 		self._assert_subtitle_data(subtitleData, fileName)
 
 	def _create_test_valid_item(self):
-		return {
-			'title': 'finding dory',
-		}
+		return { 'title': 'finding dory', }
 
 	def _assert_subtitle_data(self, subtitleData, fileName):
 		extension = os.path.splitext(fileName)[1]
@@ -74,4 +75,4 @@ class MovieTests(unittest.TestCase):
 			break
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/tests/xbmcaddon.py
+++ b/tests/xbmcaddon.py
@@ -1,3 +1,12 @@
 class Addon(object):
-	def getAddonInfo(self, type):
-		pass
+    def __init__(self, id=None):
+        pass
+
+    def getAddonInfo(self, type):
+        pass
+
+    def getSetting(self, type):
+        if type == "username": 
+            return "A"
+        elif type == "password" : 
+            return "X"

--- a/tests/xbmcaddon.py
+++ b/tests/xbmcaddon.py
@@ -5,6 +5,9 @@ class Addon(object):
     def getAddonInfo(self, type):
         pass
 
+    def openSetting(self):
+        print "Settings"
+
     def getSetting(self, type):
         if type == "username": 
             return "A"


### PR DESCRIPTION
The guest user download is now less possible due to capcha checking.
I forced user login with torec credentials as I am trying to login first (on search) - in case the login failed I am opening settings window.
In case the login succeed, I am calling get_download_link with the new params.

Tested on several machines, seems to work (and much faster - no need to wait 13 seconds anymore)

The downside is we have no guest usage.

Also - how can I become maintainer on this project, contributing to the code? 